### PR TITLE
Fixed DISPATCH_APPLY_AUTO issue

### DIFF
--- a/pstld/pstld.h
+++ b/pstld/pstld.h
@@ -26,12 +26,6 @@
 
 #if defined(PSTLD_INTERNAL_HEADER_ONLY)
     #include <dispatch/dispatch.h>
-#else
-    #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
-        #define DISPATCH_APPLY_AUTO_AVAILABLE 1
-    #else
-        #define DISPATCH_APPLY_AUTO_AVAILABLE 0
-    #endif
 #endif
 
 #include <algorithm>

--- a/pstld/pstld.h
+++ b/pstld/pstld.h
@@ -26,6 +26,12 @@
 
 #if defined(PSTLD_INTERNAL_HEADER_ONLY)
     #include <dispatch/dispatch.h>
+#else
+    #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+        #define DISPATCH_APPLY_AUTO_AVAILABLE 1
+    #else
+        #define DISPATCH_APPLY_AUTO_AVAILABLE 0
+    #endif
 #endif
 
 #include <algorithm>
@@ -3737,7 +3743,11 @@ dispatch_apply(size_t iterations, void *ctx, void (*function)(void *, size_t)) n
 {
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wnullability-extension"
-    ::dispatch_apply_f(iterations, DISPATCH_APPLY_AUTO, ctx, function);
+    #if DISPATCH_APPLY_AUTO_AVAILABLE
+        ::dispatch_apply_f(iterations, DISPATCH_APPLY_AUTO, ctx, function);
+    #else
+        ::dispatch_apply_f(iterations, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ctx, function);
+    #endif
     #pragma clang diagnostic pop
 }
 


### PR DESCRIPTION
Hello,

I have noticed some issues in some very specific cases, while making use of pstld from another library and having the HEADER_ONLY option. It results in an issue as following:

```
In file included from input_line_9:10:
In file included from ./MyLibA/Impl/TKFRImpl.h:26:
./install/include/MyLibB/std/pstld.h:3740:36: error: use of undeclared identifier 'DISPATCH_APPLY_AUTO'
    ::dispatch_apply_f(iterations, DISPATCH_APPLY_AUTO, ctx, function);
                                   ^
```

I fixed it and it should work fine after that. Please check.
Hope it helps ! Thank you for the great work :)